### PR TITLE
fix: simplify typedoc command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Lint:
 
 Generate HTML API Documentation:
 
-`bunx typedoc --readme none index.ts`
+`bunx typedoc index.ts`
 
 ## Documentation
 


### PR DESCRIPTION
Move typedoc options to package.json so the CLI command is simply \`bunx typedoc index.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)