### PR TITLE
fix: add typedocOptions to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,11 @@
   },
   "peerDependencies": {
     "typescript": "^6.0.3"
+  },
+  "typedocOptions": {
+    "readme": "none",
+    "exclude": [
+      "tests/**"
+    ]
   }
 }


### PR DESCRIPTION
Adds typedoc configuration to package.json so that `bunx typedoc index.ts` behaves correctly (readme excluded, tests directory excluded). This was missed from the previous typedoc command simplification PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)