### PR TITLE
feat: use /plugin subpath export for plugin author imports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/example-plugin",
       "dependencies": {
-        "@flowscripter/dynamic-plugin-framework": "^1.5.3",
+        "@flowscripter/dynamic-plugin-framework": "^1.6.0",
         "@flowscripter/example-plugin-api": "^1.2.4",
       },
       "devDependencies": {
@@ -19,7 +19,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.5.3", "", { "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-cDzlHQFNjyuy46STkTA+43tRW5LO/QI9IABDcjOmQc/KLnIPyj9oMoHPaZyxMotJRdYcrUUrHOfmZYcfFV8Gsw=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.6.0", "", { "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-q8S5XIcAPww5i31+c2gMpmEWAzc5ncV9tcV7VjSjewUB/sr+GgUWnTjobqxjfcIces8MxibZbSSeLhiNokxKpA=="],
 
     "@flowscripter/example-plugin-api": ["@flowscripter/example-plugin-api@1.2.4", "", { "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-ZdFy3oZ7T0UDPOxeGtMOenbJbAIrB9sQDpxJLJ85Ij5t5R3NTGSei+hVH9OEVmI8/hHEC6ABAeCTdb7RG7fXhw=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-plugin-framework": "^1.5.3",
+    "@flowscripter/dynamic-plugin-framework": "^1.6.0",
     "@flowscripter/example-plugin-api": "^1.2.4"
   },
   "devDependencies": {

--- a/src/ExamplePlugin.ts
+++ b/src/ExamplePlugin.ts
@@ -3,7 +3,7 @@ import type {
   ExtensionDescriptor,
   ExtensionFactory,
   Plugin,
-} from "@flowscripter/dynamic-plugin-framework";
+} from "@flowscripter/dynamic-plugin-framework/plugin";
 
 export const exampleExtension: ExtensionPoint1 = {
   sayHello: () => {


### PR DESCRIPTION
## Summary

- Updates the import in `src/ExamplePlugin.ts` to use `@flowscripter/dynamic-plugin-framework/plugin` instead of the main package entry point
- This keeps `DefaultPluginManager`, `UrlListPluginRepository` and other host implementation classes entirely out of the plugin module graph

## Dependency

**This PR depends on [flowscripter/dynamic-plugin-framework#65](https://github.com/flowscripter/dynamic-plugin-framework/pull/65) being merged and a new version released before CI will pass.** The `^1.5.x` version in `package.json` does not yet include the `/plugin` subpath export. Once the framework is released, `bun install` will pick up the new version automatically within the semver range.

Verified locally against the linked local build: `bunx tsc --noEmit` passes.

## Test plan

- [x] Local typecheck passes against linked local framework build
- [ ] Merge flowscripter/dynamic-plugin-framework#65 first, then CI here will pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)