### PR TITLE
build: externalize dynamic-plugin-framework as a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # example-plugin
 
 [![version](https://img.shields.io/github/v/release/flowscripter/example-plugin?sort=semver)](https://github.com/flowscripter/example-plugin/releases)
-[![build](https://img.shields.io/github/actions/workflow/status/flowscripter/example-plugin/release-bun-bundle.yml)](https://github.com/flowscripter/example-plugin/actions/workflows/release-bun-bundle.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/flowscripter/example-plugin/release-bun-library.yml)](https://github.com/flowscripter/example-plugin/actions/workflows/release-bun-library.yml)
 [![coverage](https://codecov.io/gh/flowscripter/example-plugin/branch/main/graph/badge.svg?token=EMFT2938ZF)](https://codecov.io/gh/flowscripter/example-plugin)
 [![docs](https://img.shields.io/badge/docs-API-blue)](https://flowscripter.github.io/example-plugin/index.html)
 [![license: MIT](https://img.shields.io/github/license/flowscripter/example-plugin)](https://github.com/flowscripter/example-plugin/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Bundle for usage as a
 [dynamic-plugin-framework](https://github.com/flowscripter/dynamic-plugin-framework)
 plugin:
 
-`bun build index.ts --outdir ./dist --entry-naming bundle.js --minify`
+`bun run build`
 
 Format:
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,16 @@
     "": {
       "name": "@flowscripter/example-plugin",
       "dependencies": {
-        "@flowscripter/dynamic-plugin-framework": "^1.6.12",
         "@flowscripter/example-plugin-api": "^1.2.17",
       },
       "devDependencies": {
+        "@flowscripter/dynamic-plugin-framework": "^1.6.12",
         "@types/bun": "^1.3.14",
         "oxfmt": "0.56.0",
         "oxlint": "1.71.0",
       },
       "peerDependencies": {
+        "@flowscripter/dynamic-plugin-framework": "*",
         "typescript": "^6.0.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -28,18 +28,19 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun build index.ts --outdir ./dist --entry-naming bundle.js --minify"
+    "build": "bun build index.ts --outdir ./dist --entry-naming bundle.js --minify --external \"@flowscripter/dynamic-plugin-framework\""
   },
   "dependencies": {
-    "@flowscripter/dynamic-plugin-framework": "^1.6.12",
     "@flowscripter/example-plugin-api": "^1.2.17"
   },
   "devDependencies": {
+    "@flowscripter/dynamic-plugin-framework": "^1.6.12",
     "@types/bun": "^1.3.14",
     "oxfmt": "0.56.0",
     "oxlint": "1.71.0"
   },
   "peerDependencies": {
+    "@flowscripter/dynamic-plugin-framework": "*",
     "typescript": "^6.0.3"
   },
   "typedocOptions": {


### PR DESCRIPTION
## Summary
- `@flowscripter/dynamic-plugin-framework` is only ever referenced via `import type` in `src/ExamplePlugin.ts` - it's fully erased at compile time, so nothing from it was ever bundled here.
- Move it from `dependencies` to `peerDependencies` (and add to `devDependencies` so local type-checking still resolves it) to correctly document "this plugin's types are checked against this framework version, the host supplies it" instead of implying it's shipped/bundled.
- Add `--external "@flowscripter/dynamic-plugin-framework"` to the build. This is a no-op today (nothing was ever emitted to externalize) but is a guardrail: if a future change accidentally introduces a real value import from the framework, the build will fail loudly instead of silently duplicating the framework's runtime code into the bundle.
- `@flowscripter/example-plugin-api`'s `EXTENSION_POINT_1` is a real runtime value import and is unaffected - it stays bundled normally.

Note: full bundling (rather than `--no-bundle`/plain `tsc`) is still required here because this plugin is loaded via `UrlListPluginRepository`, which fetches the bundle and caches it to a local file path outside any `node_modules` tree before `import()`-ing it - there's nothing for an externalized *value* import to resolve against at that path. This only works for `dynamic-plugin-framework` here because the only reference to it was already type-only.

## Test plan
- [x] `bun run build` succeeds, produces `dist/bundle.js`
- [x] Verified `dist/bundle.js` has zero references to `@flowscripter/dynamic-plugin-framework`, and `example-plugin-api`'s runtime value (`"foo"`) is still inlined
- [x] `bun test` passes
- [x] `bunx tsc --noEmit` passes
- [x] `bunx oxlint` passes
- [x] End-to-end: loaded the rebuilt bundle through `dynamic-plugin-framework`'s `UrlListPluginRepository` (the same mechanism `example-host-application` uses) and confirmed it still resolves and instantiates correctly